### PR TITLE
Prevent prereleases of the next version being used in tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,22 +26,22 @@ deps=
 
 [django14]
 deps=
-    Django>=1.4,<1.5a0
+    Django>=1.4,<1.5a0dev0
     {[base-south]deps}
 
 [django15]
 deps=
-    Django>=1.5,<1.6a0
+    Django>=1.5,<1.6a0dev0
     {[base-south]deps}
 
 [django16]
 deps=
-    Django>=1.6,<1.7a0
+    Django>=1.6,<1.7a0dev0
     {[base-south]deps}
 
 [django17]
 deps=
-    Django>=1.7,<1.8a0
+    Django>=1.7,<1.8a0dev0
     {[base]deps}
     django-migration-fixture==0.1.4
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,22 +26,22 @@ deps=
 
 [django14]
 deps=
-    Django>=1.4,<1.5
+    Django>=1.4,<1.5a0
     {[base-south]deps}
 
 [django15]
 deps=
-    Django>=1.5,<1.6
+    Django>=1.5,<1.6a0
     {[base-south]deps}
 
 [django16]
 deps=
-    Django>=1.6,<1.7
+    Django>=1.6,<1.7a0
     {[base-south]deps}
 
 [django17]
 deps=
-    Django>=1.7,<1.8
+    Django>=1.7,<1.8a0
     {[base]deps}
     django-migration-fixture==0.1.4
 


### PR DESCRIPTION
This fixes test failures in the py27-django17 virtualenv due to Django 1.8rc1 being installed instead of Django 1.7.7.
