### PR TITLE
Only patch south if it's in the installed apps

### DIFF
--- a/test_extras/management/commands/test.py
+++ b/test_extras/management/commands/test.py
@@ -103,12 +103,8 @@ class Command(CoreCommand):
         return bool(options['exclude_tags'] or getattr(settings, 'TEST_EXCLUDE_TAGS', None))
 
     def south_patch(self):
-        try:
-            from south.management.commands import patch_for_test_db_setup
-        except ImportError:
-            pass
-        else:
-            patch_for_test_db_setup()
+        from south.management.commands import patch_for_test_db_setup
+        patch_for_test_db_setup()
 
     def profile_wrap(self, Runner):
         class ProfileTestSuiteRunner(ProfileTestSuiteWrapper):

--- a/test_extras/management/commands/test.py
+++ b/test_extras/management/commands/test.py
@@ -65,7 +65,8 @@ class Command(CoreCommand):
 
         TestRunner = get_runner(settings)
 
-        self.south_patch()
+        if 'south' in settings.INSTALLED_APPS:
+            self.south_patch()
 
         TestRunner = result_hook_wrap(TestRunner)
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist=
     py26-django16,
     py27-django16,
     py27-django17,
+    py27-django17-with-south,
 
 [testenv]
 commands=
@@ -45,6 +46,12 @@ deps=
     {[base]deps}
     django-migration-fixture==0.1.4
 
+[django17-with-south]
+deps=
+    Django>=1.7,<1.8a0dev0
+    {[base-south]deps}
+    django-migration-fixture==0.1.4
+
 [testenv:py26-django14]
 basepython=python2.6
 deps=
@@ -79,3 +86,8 @@ deps=
 basepython=python2.7
 deps=
     {[django17]deps}
+
+[testenv:py27-django17-with-south]
+basepython=python2.7
+deps=
+    {[django17-with-south]deps}


### PR DESCRIPTION
Sometimes south gets installed as a dependency to other packages and it exists in the environment even if it's not included in the project's INSTALLED_APPS
