### PR TITLE
Use python module dynamic imports for getting app modules

### DIFF
--- a/dotted/__init__.py
+++ b/dotted/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Bright Interactive Limited. All rights reserved.
+# http://www.bright-interactive.com | info@bright-interactive.com

--- a/dotted/dotted_test_app/__init__.py
+++ b/dotted/dotted_test_app/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Bright Interactive Limited. All rights reserved.
+# http://www.bright-interactive.com | info@bright-interactive.com

--- a/dotted/dotted_test_app/tests.py
+++ b/dotted/dotted_test_app/tests.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Bright Interactive Limited. All rights reserved.
+# http://www.bright-interactive.com | info@bright-interactive.com
+import os
+from django.test.testcases import TestCase
+from dotted import dotted_test_app
+from test_extras.testrunners import get_coverage_files
+
+
+class CoverageTests(TestCase):
+
+    def test_get_coverage_works_for_dotted_app_labels(self):
+        files = get_coverage_files(
+            ['dotted.dotted_test_app'],
+            ignore_dirs=[],
+            ignore_files=['tests.py']
+        )
+
+        self.assertEqual(1, len(files))
+        expected_path = os.path.join(os.path.dirname(dotted_test_app.__file__), '__init__.py')
+        self.assertIn(expected_path, files)

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -2,8 +2,11 @@
 # (c) 2013 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
 from django.test import TestCase, TransactionTestCase
+import test_app
+import os
 from test_extras.testcases import DataPreservingTransactionTestCaseMixin
 from test_app.models import Painter
+from test_extras.testrunners import get_coverage_files
 
 
 class TestDataPreserving(DataPreservingTransactionTestCaseMixin, TransactionTestCase):
@@ -35,3 +38,13 @@ class HookTests(TestCase):
 
     def test_2_check(self):
         self.assertTrue(HookTests.addSuccess_called)
+
+
+class CoverageTests(TestCase):
+
+    def test_get_coverage_gets_the_expected_files(self):
+        coverage_files = get_coverage_files(['test_app'], ignore_dirs=['south_migrations', 'migrations', 'fixtures'], ignore_files=['tests.py'])
+        expected_coverage_file_names = ['__init__.py', 'views.py', 'models.py']
+        full_paths = [os.path.join(os.path.dirname(test_app.__file__), file_name) for file_name in expected_coverage_file_names]
+        self.assertEqual(len(full_paths), len(coverage_files))
+        self.assertTrue(all(path in coverage_files for path in full_paths))

--- a/test_app_no_models/tests.py
+++ b/test_app_no_models/tests.py
@@ -1,0 +1,14 @@
+from django.test.testcases import TestCase
+import test_app_no_models
+import os
+from test_extras.testrunners import get_coverage_files
+
+
+class CoverageTests(TestCase):
+
+    def test_get_coverage_gets_the_expected_files(self):
+        coverage_files = get_coverage_files(['test_app_no_models'], ignore_dirs=[], ignore_files=['tests.py'])
+        expected_coverage_file_names = ['__init__.py', 'views.py']
+        full_paths = [os.path.join(os.path.dirname(test_app_no_models.__file__), file_name) for file_name in expected_coverage_file_names]
+        self.assertEqual(len(full_paths), len(coverage_files))
+        self.assertTrue(all(path in coverage_files for path in full_paths))

--- a/test_app_no_models/views.py
+++ b/test_app_no_models/views.py
@@ -1,0 +1,1 @@
+# Create your views here.

--- a/test_extras/testrunners.py
+++ b/test_extras/testrunners.py
@@ -129,17 +129,17 @@ def get_coverage_files(app_labels, ignore_dirs, ignore_files):
     return a list of all the python files that should be included in
     a coverage report for that test.
     """
-    ret = []
+    files_for_coverage = []
 
     for app_label in app_labels:
         if app_label in settings.INSTALLED_APPS:
-            module = __import__(app_label, fromlist=[''])
+            module = __import__(app_label, globals(), locals(), [''], -1)
             dirname = os.path.dirname(module.__file__)
-            ret.extend(get_coverage_files_in_directory(dirname, ignore_dirs, ignore_files))
+            files_for_coverage.extend(get_coverage_files_in_directory(dirname, ignore_dirs, ignore_files))
         else:
             raise ImproperlyConfigured('%s is not installed' % app_label)
 
-    return ret
+    return files_for_coverage
 
 
 class ExceptionTestResultMixin(object):

--- a/test_extras/tests.py
+++ b/test_extras/tests.py
@@ -1,10 +1,19 @@
 # -*- coding: utf-8 -*-
 # (c) 2012 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
+import os
+from django.core.exceptions import ImproperlyConfigured
 
 from django.test import TestCase
+from django.test.utils import override_settings
+import test_extras.management
+from test_extras.testrunners import get_coverage_files
 
 
-class TestStuff(TestCase):
-    def test_something(self):
-        self.assertEquals(2, 1 + 1)
+class CoverageTests(TestCase):
+
+    @override_settings(INSTALLED_APPS=[])
+    def test_get_coverage_raises_error_if_app_is_not_installed(self):
+        with self.assertRaises(ImproperlyConfigured):
+            get_coverage_files(['test'], ignore_dirs=[], ignore_files=[])
+

--- a/testsettings.py
+++ b/testsettings.py
@@ -11,6 +11,8 @@ DATABASES = {
 INSTALLED_APPS = (
     'test_extras',
     'test_app',
+    'test_app_no_models',
+    'dotted.dotted_test_app',
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
Using get_app requires apps to have a models module even though this is not required anymore

Fixes #6
