### PR TITLE
Django 1.10 compatibility: Don't use deprecated management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ then simply run `tox`:
 Changelog
 =========
 
+3.0.2
+-----
+* Fix usage of deprecated NoArgsCommand to use BaseCommand: https://docs.djangoproject.com/en/1.8/releases/1.8/#django-core-management-noargscommand
+
 3.0.1
 -----
 * Fix issue with `dumpdata` attempting to access unmanaged models. 

--- a/test_extras/management/commands/superflush.py
+++ b/test_extras/management/commands/superflush.py
@@ -1,13 +1,13 @@
 from optparse import make_option
 
 from django.db import connections, transaction, DEFAULT_DB_ALIAS
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError
 from django.core.management.color import no_style
 from django.core.management.sql import sql_flush
 
 
-class Command(NoArgsCommand):
-    option_list = NoArgsCommand.option_list + (
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
         make_option('--noinput', action='store_false', dest='interactive', default=True,
             help='Tells Django to NOT prompt the user for input of any kind.'),
         make_option('--database', action='store', dest='database',
@@ -16,7 +16,7 @@ class Command(NoArgsCommand):
     )
     help = ('Deletes all data from the database, and unlike the built in flush command does NOT restore data by executing post-synchronization handlers or loading the initial_data fixture will be re-installed.')
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         db = options.get('database')
         connection = connections[db]
         verbosity = int(options.get('verbosity'))


### PR DESCRIPTION
    The NoArgsCommand has been deprecated since 1.8, which is our
    current supported version.
    https://docs.djangoproject.com/en/1.8/releases/1.8/#django-core-management-noargscommand